### PR TITLE
Fix support for firewall cookbook >=2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,10 +46,13 @@ node['firewall']['rules'].each do |rule_mash|
     Chef::Log.debug "ufw:rule:destination #{params['destination']}" if params['destination']
     Chef::Log.debug "ufw:rule:dest_port #{params['dest_port']}" if params['dest_port']
     Chef::Log.debug "ufw:rule:position #{params['position']}" if params['position']
-    act = params['action']
-    act ||= 'create'
+
+    act = params['action'] ? params['action'].to_sym : :allow
+
     raise 'ufw: port_range was specified to firewall_rule without protocol' if params['port_range'] && !params['protocol']
+
     Chef::Log.debug "ufw:rule:action :#{act}"
+
     firewall_rule rule do
       name params['name'] if params['name']
       protocol params['protocol'].to_sym if params['protocol']
@@ -65,7 +68,7 @@ node['firewall']['rules'].each do |rule_mash|
       destination params['destination'] if params['destination']
       dest_port params['dest_port'].to_i if params['dest_port']
       position params['position'].to_i if params['position']
-      action act
+      command act
     end
   end
 end


### PR DESCRIPTION
The only valid `action` attribute is `:create` and the ufw actions (`allow`, `deny`, etc) are set with `command`.

The previous functionality was deprecated after version `1.6.2`.